### PR TITLE
✨ Add begin/end of (stack_)pool_allocators

### DIFF
--- a/include/cpp_yyjson.hpp
+++ b/include/cpp_yyjson.hpp
@@ -3185,7 +3185,9 @@ namespace yyjson
             auto& get() & { return alc_; }
             [[nodiscard]] const auto& get() const& { return alc_; }
             auto get() && { return std::move(alc_); }
-            [[nodiscard]] auto size() const { return buf_.size(); }
+            [[nodiscard]] constexpr auto begin() noexcept { return buf_.begin(); }
+            [[nodiscard]] constexpr auto end() noexcept { return buf_.end(); }
+            [[nodiscard]] constexpr auto size() const noexcept { return buf_.size(); }
             void resize(std::size_t req)
             {
                 buf_.resize(req);
@@ -3235,7 +3237,9 @@ namespace yyjson
             stack_pool_allocator() = default;
             stack_pool_allocator(const stack_pool_allocator&) = default;
             stack_pool_allocator(stack_pool_allocator&&) noexcept = default;
-            [[nodiscard]] constexpr auto size() const { return buf_.size(); }
+            [[nodiscard]] constexpr auto begin() noexcept { return buf_.begin(); }
+            [[nodiscard]] constexpr auto end() noexcept { return buf_.end(); }
+            [[nodiscard]] constexpr auto size() const noexcept { return buf_.size(); }
             [[nodiscard]] bool check_capacity(std::string_view json, ReadFlag flag = ReadFlag::NoFlag) const
             {
                 return size() >= yyjson_read_max_memory_usage(json.size(), to_underlying(flag));


### PR DESCRIPTION
`(stack_)pool_allocato`rがrangeコンセプトを満たしてほしい状況があったので、`begin()`と`end()`関数を追加しました。

また、`begin()`, `end()`と併せて`size()`に`constexpr`修飾と`noexcept`修飾を行いました。

Clang 16とGCC 12でテストパスを確認しております。

御確認と御検討の程、どうぞ宜しくお願いいたします。