### PR TITLE
🔧 Allow superproject to provide dependencies with add_subdirectory()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,9 @@ endif()
 
 # dependencies
 function(find_and_link package_name qualified_name)
-  if(NOT TARGET ${package_name})
-    find_package(${package_name} CONFIG REQUIRED)
+  cmake_parse_arguments(FIND_AND_LINK "" "VERSION" "" ${ARGN})
+  if(NOT TARGET ${package_name} OR CPPYYJSON_IS_TOPLEVEL_PROJECT)
+    find_package(${package_name} ${FIND_AND_LINK_VERSION} CONFIG REQUIRED)
     target_link_libraries(${PROJECT_NAME} INTERFACE ${qualified_name})
   else()
     target_link_libraries(${PROJECT_NAME} INTERFACE ${package_name})
@@ -43,8 +44,8 @@ function(find_and_link package_name qualified_name)
 endfunction()
 
 find_and_link(yyjson yyjson::yyjson)
-find_and_link(fmt fmt::fmt-header-only)
-find_and_link(nameof nameof::nameof)
+find_and_link(fmt fmt::fmt-header-only VERSION 10.0.0)
+find_and_link(nameof nameof::nameof VERSION 0.10.0)
 
 # install
 if(CPPYYJSON_IS_TOPLEVEL_PROJECT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,18 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 endif()
 
 # dependencies
-find_package(yyjson CONFIG REQUIRED)
-target_link_libraries(${PROJECT_NAME} INTERFACE yyjson::yyjson)
-find_package(fmt 10.0.0 CONFIG REQUIRED)
-target_link_libraries(${PROJECT_NAME} INTERFACE fmt::fmt-header-only)
-find_package(nameof CONFIG REQUIRED)
-target_link_libraries(${PROJECT_NAME} INTERFACE nameof::nameof)
+function(find_and_link package_name qualified_name)
+  if(NOT TARGET ${package_name})
+    find_package(${package_name} CONFIG REQUIRED)
+    target_link_libraries(${PROJECT_NAME} INTERFACE ${qualified_name})
+  else()
+    target_link_libraries(${PROJECT_NAME} INTERFACE ${package_name})
+  endif()
+endfunction()
+
+find_and_link(yyjson yyjson::yyjson)
+find_and_link(fmt fmt::fmt-header-only)
+find_and_link(nameof nameof::nameof)
 
 # install
 if(CPPYYJSON_IS_TOPLEVEL_PROJECT)


### PR DESCRIPTION
This lets a superproject vendor cpp-yyjson along with these dependencies, doing something like:

```cmake
add_subdirectory(yyjson)
add_subdirectory(fmt)
add_subdirectory(nameof)
add_subdirectory(cpp-yyjson)
```

and cpp-yyjson will use the dependencies provided by the parent Cmake project, without trying to find them installed.